### PR TITLE
Added classes to support lists provided by Extension:FlaggedRevs

### DIFF
--- a/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/OldreviewedPagesTitles.java
+++ b/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/OldreviewedPagesTitles.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public class OldreviewedPagesTitles extends BaseQuery<String> {
 
-    private static final Logger log = LoggerFactory.getLogger(net.sourceforge.jwbf.mediawiki.actions.queries.RecentchangeTitles.class);
+    private static final Logger log = LoggerFactory.getLogger(RecentchangeTitles.class);
     /**
      * value for the orlimit-parameter.
      */
@@ -64,7 +64,8 @@ public class OldreviewedPagesTitles extends BaseQuery<String> {
                 .param("orlimit", LIMIT) //
                 ;
         if (namespace != null) {
-            requestBuilder.param("ornamespace", MediaWiki.urlEncode(MWAction.createNsString(namespace)));
+            String ornamespace = MediaWiki.urlEncode(MWAction.createNsString(namespace));
+            requestBuilder.param("ornamespace", ornamespace);
         }
         if (orstart.length() > 0) {
             requestBuilder.param("orstart", orstart);
@@ -141,7 +142,7 @@ public class OldreviewedPagesTitles extends BaseQuery<String> {
 
     @Override
     protected Iterator<String> copy() {
-        return new net.sourceforge.jwbf.mediawiki.actions.queries.OldreviewedPagesTitles(bot, namespaces);
+        return new OldreviewedPagesTitles(bot, namespaces);
     }
 
     @Override

--- a/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/OldreviewedPagesTitles.java
+++ b/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/OldreviewedPagesTitles.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2016 Thomas Stock, Marco Ammon.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.sourceforge.jwbf.mediawiki.actions.queries;
+
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import java.util.Iterator;
+import java.util.List;
+import net.sourceforge.jwbf.core.actions.RequestBuilder;
+import net.sourceforge.jwbf.core.actions.util.HttpAction;
+import net.sourceforge.jwbf.mapper.XmlConverter;
+import net.sourceforge.jwbf.mapper.XmlElement;
+import net.sourceforge.jwbf.mediawiki.ApiRequestBuilder;
+import net.sourceforge.jwbf.mediawiki.MediaWiki;
+import net.sourceforge.jwbf.mediawiki.actions.util.MWAction;
+import net.sourceforge.jwbf.mediawiki.bots.MediaWikiBot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Gets a list of pages with unreviewed changes.
+ *
+ * @author Thomas Stock, Marco Ammon
+ */
+public class OldreviewedPagesTitles extends BaseQuery<String> {
+
+  private static final Logger log = LoggerFactory.getLogger(net.sourceforge.jwbf.mediawiki.actions.queries.RecentchangeTitles.class);
+
+  /**
+   * value for the orlimit-parameter.
+   */
+  private static final int LIMIT = 50;
+
+  private final MediaWikiBot bot;
+
+  private final int[] namespaces;
+
+  /**
+   * generates the next MediaWiki-request (GetMethod) and adds it to msgs.
+   *
+   * @param namespace the namespace(s) that will be searched for links, as a string of numbers
+   *                  separated by '|'; if null, this parameter is omitted
+   * @param orstart   Start listing at this page title
+   * 
+   * @param orend     Stop listing at this page title
+   */
+  private HttpAction generateRequest(int[] namespace, String orstart, String orend) {
+
+    RequestBuilder requestBuilder = new ApiRequestBuilder() //
+        .action("query") //
+        .formatXml() //
+        .param("list", "oldreviewedpages") //
+        .param("orlimit", LIMIT) //
+        ;
+    if (namespace != null) {
+      requestBuilder.param("ornamespace", MediaWiki.urlEncode(MWAction.createNsString(namespace)));
+    }
+    if (orstart.length() > 0) {
+      requestBuilder.param("orstart", orstart);
+    }
+    if (orend.length() > 0) {
+      requestBuilder.param("orend", orend);
+    }
+
+    return requestBuilder.buildGet();
+
+  }
+  
+  private HttpAction generateRequest(int[] namespace, String orstart){
+      return generateRequest(namespace, orstart, "");
+  }
+  
+  private HttpAction generateRequest(int[] namespace) {
+    return generateRequest(namespace, "", "");
+  }
+
+  /**
+   *
+   */
+  public OldreviewedPagesTitles(MediaWikiBot bot, int... ns) {
+    super(bot);
+    namespaces = ns;
+    this.bot = bot;
+
+  }
+
+  /**
+   *
+   */
+  public OldreviewedPagesTitles(MediaWikiBot bot) {
+    this(bot, MediaWiki.NS_ALL);
+  }
+
+  /**
+   * picks the article name from a MediaWiki api response.
+   *
+   * @param s text for parsing
+   */
+  @Override
+  protected ImmutableList<String> parseElements(String s) {
+    XmlElement root = XmlConverter.getRootElement(s);
+    List<String> titleCollection = Lists.newArrayList();
+    findContent(root, titleCollection);
+    return ImmutableList.copyOf(titleCollection);
+
+  }
+
+  private void findContent(final XmlElement root, List<String> titleCollection) {
+
+    for (XmlElement xmlElement : root.getChildren()) {
+      if (xmlElement.getQualifiedName().equalsIgnoreCase("p")) {
+        titleCollection.add(MediaWiki.htmlUnescape(xmlElement.getAttributeValue("title")));
+        setNextPageInfo(xmlElement.getAttributeValue("title"));
+      } else {
+        findContent(xmlElement, titleCollection);
+      }
+
+    }
+  }
+
+  @Override
+  protected HttpAction prepareNextRequest() {
+    if (hasNextPageInfo()) {
+      return generateRequest(namespaces, getNextPageInfo());
+    } else {
+      return generateRequest(namespaces);
+    }
+
+  }
+
+  @Override
+  protected Iterator<String> copy() {
+    return new net.sourceforge.jwbf.mediawiki.actions.queries.OldreviewedPagesTitles(bot, namespaces);
+  }
+
+  @Override
+  protected Optional<String> parseHasMore(String s) {
+    return Optional.absent();
+  }
+
+}

--- a/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/OldreviewedPagesTitles.java
+++ b/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/OldreviewedPagesTitles.java
@@ -15,7 +15,6 @@
  */
 package net.sourceforge.jwbf.mediawiki.actions.queries;
 
-
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -39,118 +38,114 @@ import org.slf4j.LoggerFactory;
  */
 public class OldreviewedPagesTitles extends BaseQuery<String> {
 
-  private static final Logger log = LoggerFactory.getLogger(net.sourceforge.jwbf.mediawiki.actions.queries.RecentchangeTitles.class);
+    private static final Logger log = LoggerFactory.getLogger(net.sourceforge.jwbf.mediawiki.actions.queries.RecentchangeTitles.class);
+    /**
+     * value for the orlimit-parameter.
+     */
+    private static final int LIMIT = 50;
+    private final MediaWikiBot bot;
+    private final int[] namespaces;
 
-  /**
-   * value for the orlimit-parameter.
-   */
-  private static final int LIMIT = 50;
+    /**
+     * generates the next MediaWiki-request (GetMethod) and adds it to msgs.
+     *
+     * @param namespace the namespace(s) that will be searched for links, as a
+     * string of numbers separated by '|'; if null, this parameter is omitted
+     * @param orstart Start listing at this timestamp
+     *
+     * @param orend Stop listing at this timestamp
+     */
+    private HttpAction generateRequest(int[] namespace, String orstart, String orend) {
 
-  private final MediaWikiBot bot;
+        RequestBuilder requestBuilder = new ApiRequestBuilder() //
+                .action("query") //
+                .formatXml() //
+                .param("list", "oldreviewedpages") //
+                .param("orlimit", LIMIT) //
+                ;
+        if (namespace != null) {
+            requestBuilder.param("ornamespace", MediaWiki.urlEncode(MWAction.createNsString(namespace)));
+        }
+        if (orstart.length() > 0) {
+            requestBuilder.param("orstart", orstart);
+        }
+        if (orend.length() > 0) {
+            requestBuilder.param("orend", orend);
+        }
 
-  private final int[] namespaces;
-
-  /**
-   * generates the next MediaWiki-request (GetMethod) and adds it to msgs.
-   *
-   * @param namespace the namespace(s) that will be searched for links, as a string of numbers
-   *                  separated by '|'; if null, this parameter is omitted
-   * @param orstart   Start listing at this page title
-   * 
-   * @param orend     Stop listing at this page title
-   */
-  private HttpAction generateRequest(int[] namespace, String orstart, String orend) {
-
-    RequestBuilder requestBuilder = new ApiRequestBuilder() //
-        .action("query") //
-        .formatXml() //
-        .param("list", "oldreviewedpages") //
-        .param("orlimit", LIMIT) //
-        ;
-    if (namespace != null) {
-      requestBuilder.param("ornamespace", MediaWiki.urlEncode(MWAction.createNsString(namespace)));
-    }
-    if (orstart.length() > 0) {
-      requestBuilder.param("orstart", orstart);
-    }
-    if (orend.length() > 0) {
-      requestBuilder.param("orend", orend);
-    }
-
-    return requestBuilder.buildGet();
-
-  }
-  
-  private HttpAction generateRequest(int[] namespace, String orstart){
-      return generateRequest(namespace, orstart, "");
-  }
-  
-  private HttpAction generateRequest(int[] namespace) {
-    return generateRequest(namespace, "", "");
-  }
-
-  /**
-   *
-   */
-  public OldreviewedPagesTitles(MediaWikiBot bot, int... ns) {
-    super(bot);
-    namespaces = ns;
-    this.bot = bot;
-
-  }
-
-  /**
-   *
-   */
-  public OldreviewedPagesTitles(MediaWikiBot bot) {
-    this(bot, MediaWiki.NS_ALL);
-  }
-
-  /**
-   * picks the article name from a MediaWiki api response.
-   *
-   * @param s text for parsing
-   */
-  @Override
-  protected ImmutableList<String> parseElements(String s) {
-    XmlElement root = XmlConverter.getRootElement(s);
-    List<String> titleCollection = Lists.newArrayList();
-    findContent(root, titleCollection);
-    return ImmutableList.copyOf(titleCollection);
-
-  }
-
-  private void findContent(final XmlElement root, List<String> titleCollection) {
-
-    for (XmlElement xmlElement : root.getChildren()) {
-      if (xmlElement.getQualifiedName().equalsIgnoreCase("p")) {
-        titleCollection.add(MediaWiki.htmlUnescape(xmlElement.getAttributeValue("title")));
-        setNextPageInfo(xmlElement.getAttributeValue("title"));
-      } else {
-        findContent(xmlElement, titleCollection);
-      }
+        return requestBuilder.buildGet();
 
     }
-  }
 
-  @Override
-  protected HttpAction prepareNextRequest() {
-    if (hasNextPageInfo()) {
-      return generateRequest(namespaces, getNextPageInfo());
-    } else {
-      return generateRequest(namespaces);
+    private HttpAction generateRequest(int[] namespace, String orstart) {
+        return generateRequest(namespace, orstart, "");
     }
 
-  }
+    private HttpAction generateRequest(int[] namespace) {
+        return generateRequest(namespace, "", "");
+    }
 
-  @Override
-  protected Iterator<String> copy() {
-    return new net.sourceforge.jwbf.mediawiki.actions.queries.OldreviewedPagesTitles(bot, namespaces);
-  }
+    /**
+     *
+     */
+    public OldreviewedPagesTitles(MediaWikiBot bot, int... ns) {
+        super(bot);
+        namespaces = ns;
+        this.bot = bot;
 
-  @Override
-  protected Optional<String> parseHasMore(String s) {
-    return Optional.absent();
-  }
+    }
 
+    /**
+     *
+     */
+    public OldreviewedPagesTitles(MediaWikiBot bot) {
+        this(bot, MediaWiki.NS_ALL);
+    }
+
+    /**
+     * picks the article name from a MediaWiki api response.
+     *
+     * @param s text for parsing
+     */
+    @Override
+    protected ImmutableList<String> parseElements(String s) {
+        XmlElement root = XmlConverter.getRootElement(s);
+        List<String> titleCollection = Lists.newArrayList();
+        findContent(root, titleCollection);
+        return ImmutableList.copyOf(titleCollection);
+
+    }
+
+    private void findContent(final XmlElement root, List<String> titleCollection) {
+
+        for (XmlElement xmlElement : root.getChildren()) {
+            if (xmlElement.getQualifiedName().equalsIgnoreCase("p")) {
+                titleCollection.add(MediaWiki.htmlUnescape(xmlElement.getAttributeValue("title")));
+            } else {
+                findContent(xmlElement, titleCollection);
+            }
+
+        }
+    }
+
+    @Override
+    protected HttpAction prepareNextRequest() {
+        Optional<String> orcontinue = nextPageInfoOpt();
+        if (orcontinue.isPresent()) {
+            return generateRequest(namespaces, orcontinue.get());
+        } else {
+            return generateRequest(namespaces);
+        }
+
+    }
+
+    @Override
+    protected Iterator<String> copy() {
+        return new net.sourceforge.jwbf.mediawiki.actions.queries.OldreviewedPagesTitles(bot, namespaces);
+    }
+
+    @Override
+    protected Optional<String> parseHasMore(final String xml) {
+        return parseXmlHasMore(xml, "oldreviewedpages", "orstart", "orstart");
+    }
 }

--- a/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/ReviewedPagesTitles.java
+++ b/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/ReviewedPagesTitles.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2016 Thomas Stock, Marco Ammon.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.sourceforge.jwbf.mediawiki.actions.queries;
+
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import java.util.Iterator;
+import java.util.List;
+import net.sourceforge.jwbf.core.actions.RequestBuilder;
+import net.sourceforge.jwbf.core.actions.util.HttpAction;
+import net.sourceforge.jwbf.mapper.XmlConverter;
+import net.sourceforge.jwbf.mapper.XmlElement;
+import net.sourceforge.jwbf.mediawiki.ApiRequestBuilder;
+import net.sourceforge.jwbf.mediawiki.MediaWiki;
+import net.sourceforge.jwbf.mediawiki.actions.util.MWAction;
+import net.sourceforge.jwbf.mediawiki.bots.MediaWikiBot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Gets a list of reviewed pages.
+ *
+ * @author Thomas Stock, Marco Ammon
+ */
+public class ReviewedPagesTitles extends BaseQuery<String> {
+
+  private static final Logger log = LoggerFactory.getLogger(net.sourceforge.jwbf.mediawiki.actions.queries.RecentchangeTitles.class);
+
+  /**
+   * value for the rplimit-parameter.
+   */
+  private static final int LIMIT = 50;
+
+  private final MediaWikiBot bot;
+
+  private final int[] namespaces;
+
+  /**
+   * generates the next MediaWiki-request (GetMethod) and adds it to msgs.
+   *
+   * @param namespace the namespace(s) that will be searched for links, as a string of numbers
+   *                  separated by '|'; if null, this parameter is omitted
+   * @param rpstart   Start listing at this page title
+   * 
+   * @param rpend     Stop listing at this page title
+   */
+  private HttpAction generateRequest(int[] namespace, String rpstart, String rpend) {
+
+    RequestBuilder requestBuilder = new ApiRequestBuilder() //
+        .action("query") //
+        .formatXml() //
+        .param("list", "reviewedpages") //
+        .param("rplimit", LIMIT) //
+        ;
+    if (namespace != null) {
+      requestBuilder.param("rpnamespace", MediaWiki.urlEncode(MWAction.createNsString(namespace)));
+    }
+    if (rpstart.length() > 0) {
+      requestBuilder.param("rpstart", rpstart);
+    }
+    if (rpend.length() > 0) {
+      requestBuilder.param("rpend", rpend);
+    }
+
+    return requestBuilder.buildGet();
+
+  }
+  
+  private HttpAction generateRequest(int[] namespace, String orstart){
+      return generateRequest(namespace, orstart, "");
+  }
+  
+  private HttpAction generateRequest(int[] namespace) {
+    return generateRequest(namespace, "", "");
+  }
+
+  /**
+   *
+   */
+  public ReviewedPagesTitles(MediaWikiBot bot, int... ns) {
+    super(bot);
+    namespaces = ns;
+    this.bot = bot;
+
+  }
+
+  /**
+   *
+   */
+  public ReviewedPagesTitles(MediaWikiBot bot) {
+    this(bot, MediaWiki.NS_ALL);
+  }
+
+  /**
+   * picks the article name from a MediaWiki api response.
+   *
+   * @param s text for parsing
+   */
+  @Override
+  protected ImmutableList<String> parseElements(String s) {
+    XmlElement root = XmlConverter.getRootElement(s);
+    List<String> titleCollection = Lists.newArrayList();
+    findContent(root, titleCollection);
+    return ImmutableList.copyOf(titleCollection);
+
+  }
+
+  private void findContent(final XmlElement root, List<String> titleCollection) {
+
+    for (XmlElement xmlElement : root.getChildren()) {
+      if (xmlElement.getQualifiedName().equalsIgnoreCase("p")) {
+        titleCollection.add(MediaWiki.htmlUnescape(xmlElement.getAttributeValue("title")));
+        setNextPageInfo(xmlElement.getAttributeValue("title"));
+      } else {
+        findContent(xmlElement, titleCollection);
+      }
+
+    }
+  }
+
+  @Override
+  protected HttpAction prepareNextRequest() {
+    if (hasNextPageInfo()) {
+      return generateRequest(namespaces, getNextPageInfo());
+    } else {
+      return generateRequest(namespaces);
+    }
+
+  }
+
+  @Override
+  protected Iterator<String> copy() {
+    return new net.sourceforge.jwbf.mediawiki.actions.queries.OldreviewedPagesTitles(bot, namespaces);
+  }
+
+  @Override
+  protected Optional<String> parseHasMore(String s) {
+    return Optional.absent();
+  }
+
+}

--- a/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/ReviewedPagesTitles.java
+++ b/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/ReviewedPagesTitles.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ReviewedPagesTitles extends BaseQuery<String> {
 
-    private static final Logger log = LoggerFactory.getLogger(net.sourceforge.jwbf.mediawiki.actions.queries.RecentchangeTitles.class);
+    private static final Logger log = LoggerFactory.getLogger(RecentchangeTitles.class);
     /**
      * value for the rplimit-parameter.
      */
@@ -64,7 +64,8 @@ public class ReviewedPagesTitles extends BaseQuery<String> {
                 .param("rplimit", LIMIT) //
                 ;
         if (namespace != null) {
-            requestBuilder.param("rpnamespace", MediaWiki.urlEncode(MWAction.createNsString(namespace)));
+            String rpnamespace = MediaWiki.urlEncode(MWAction.createNsString(namespace));
+            requestBuilder.param("rpnamespace", rpnamespace);
         }
         if (rpstart.length() > 0) {
             requestBuilder.param("rpstart", rpstart);
@@ -141,7 +142,7 @@ public class ReviewedPagesTitles extends BaseQuery<String> {
 
     @Override
     protected Iterator<String> copy() {
-        return new net.sourceforge.jwbf.mediawiki.actions.queries.OldreviewedPagesTitles(bot, namespaces);
+        return new OldreviewedPagesTitles(bot, namespaces);
     }
 
     @Override

--- a/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/ReviewedPagesTitles.java
+++ b/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/ReviewedPagesTitles.java
@@ -15,7 +15,6 @@
  */
 package net.sourceforge.jwbf.mediawiki.actions.queries;
 
-
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -39,118 +38,114 @@ import org.slf4j.LoggerFactory;
  */
 public class ReviewedPagesTitles extends BaseQuery<String> {
 
-  private static final Logger log = LoggerFactory.getLogger(net.sourceforge.jwbf.mediawiki.actions.queries.RecentchangeTitles.class);
+    private static final Logger log = LoggerFactory.getLogger(net.sourceforge.jwbf.mediawiki.actions.queries.RecentchangeTitles.class);
+    /**
+     * value for the rplimit-parameter.
+     */
+    private static final int LIMIT = 50;
+    private final MediaWikiBot bot;
+    private final int[] namespaces;
 
-  /**
-   * value for the rplimit-parameter.
-   */
-  private static final int LIMIT = 50;
+    /**
+     * generates the next MediaWiki-request (GetMethod) and adds it to msgs.
+     *
+     * @param namespace the namespace(s) that will be searched for links, as a
+     * string of numbers separated by '|'; if null, this parameter is omitted
+     * @param rpstart Start listing at this page id
+     *
+     * @param rpend Stop listing at this page id
+     */
+    private HttpAction generateRequest(int[] namespace, String rpstart, String rpend) {
 
-  private final MediaWikiBot bot;
+        RequestBuilder requestBuilder = new ApiRequestBuilder() //
+                .action("query") //
+                .formatXml() //
+                .param("list", "reviewedpages") //
+                .param("rplimit", LIMIT) //
+                ;
+        if (namespace != null) {
+            requestBuilder.param("rpnamespace", MediaWiki.urlEncode(MWAction.createNsString(namespace)));
+        }
+        if (rpstart.length() > 0) {
+            requestBuilder.param("rpstart", rpstart);
+        }
+        if (rpend.length() > 0) {
+            requestBuilder.param("rpend", rpend);
+        }
 
-  private final int[] namespaces;
-
-  /**
-   * generates the next MediaWiki-request (GetMethod) and adds it to msgs.
-   *
-   * @param namespace the namespace(s) that will be searched for links, as a string of numbers
-   *                  separated by '|'; if null, this parameter is omitted
-   * @param rpstart   Start listing at this page title
-   * 
-   * @param rpend     Stop listing at this page title
-   */
-  private HttpAction generateRequest(int[] namespace, String rpstart, String rpend) {
-
-    RequestBuilder requestBuilder = new ApiRequestBuilder() //
-        .action("query") //
-        .formatXml() //
-        .param("list", "reviewedpages") //
-        .param("rplimit", LIMIT) //
-        ;
-    if (namespace != null) {
-      requestBuilder.param("rpnamespace", MediaWiki.urlEncode(MWAction.createNsString(namespace)));
-    }
-    if (rpstart.length() > 0) {
-      requestBuilder.param("rpstart", rpstart);
-    }
-    if (rpend.length() > 0) {
-      requestBuilder.param("rpend", rpend);
-    }
-
-    return requestBuilder.buildGet();
-
-  }
-  
-  private HttpAction generateRequest(int[] namespace, String orstart){
-      return generateRequest(namespace, orstart, "");
-  }
-  
-  private HttpAction generateRequest(int[] namespace) {
-    return generateRequest(namespace, "", "");
-  }
-
-  /**
-   *
-   */
-  public ReviewedPagesTitles(MediaWikiBot bot, int... ns) {
-    super(bot);
-    namespaces = ns;
-    this.bot = bot;
-
-  }
-
-  /**
-   *
-   */
-  public ReviewedPagesTitles(MediaWikiBot bot) {
-    this(bot, MediaWiki.NS_ALL);
-  }
-
-  /**
-   * picks the article name from a MediaWiki api response.
-   *
-   * @param s text for parsing
-   */
-  @Override
-  protected ImmutableList<String> parseElements(String s) {
-    XmlElement root = XmlConverter.getRootElement(s);
-    List<String> titleCollection = Lists.newArrayList();
-    findContent(root, titleCollection);
-    return ImmutableList.copyOf(titleCollection);
-
-  }
-
-  private void findContent(final XmlElement root, List<String> titleCollection) {
-
-    for (XmlElement xmlElement : root.getChildren()) {
-      if (xmlElement.getQualifiedName().equalsIgnoreCase("p")) {
-        titleCollection.add(MediaWiki.htmlUnescape(xmlElement.getAttributeValue("title")));
-        setNextPageInfo(xmlElement.getAttributeValue("title"));
-      } else {
-        findContent(xmlElement, titleCollection);
-      }
+        return requestBuilder.buildGet();
 
     }
-  }
 
-  @Override
-  protected HttpAction prepareNextRequest() {
-    if (hasNextPageInfo()) {
-      return generateRequest(namespaces, getNextPageInfo());
-    } else {
-      return generateRequest(namespaces);
+    private HttpAction generateRequest(int[] namespace, String rpstart) {
+        return generateRequest(namespace, rpstart, "");
     }
 
-  }
+    private HttpAction generateRequest(int[] namespace) {
+        return generateRequest(namespace, "", "");
+    }
 
-  @Override
-  protected Iterator<String> copy() {
-    return new net.sourceforge.jwbf.mediawiki.actions.queries.OldreviewedPagesTitles(bot, namespaces);
-  }
+    /**
+     *
+     */
+    public ReviewedPagesTitles(MediaWikiBot bot, int... ns) {
+        super(bot);
+        namespaces = ns;
+        this.bot = bot;
 
-  @Override
-  protected Optional<String> parseHasMore(String s) {
-    return Optional.absent();
-  }
+    }
 
+    /**
+     *
+     */
+    public ReviewedPagesTitles(MediaWikiBot bot) {
+        this(bot, MediaWiki.NS_ALL);
+    }
+
+    /**
+     * picks the article name from a MediaWiki api response.
+     *
+     * @param s text for parsing
+     */
+    @Override
+    protected ImmutableList<String> parseElements(String s) {
+        XmlElement root = XmlConverter.getRootElement(s);
+        List<String> titleCollection = Lists.newArrayList();
+        findContent(root, titleCollection);
+        return ImmutableList.copyOf(titleCollection);
+
+    }
+
+    private void findContent(final XmlElement root, List<String> titleCollection) {
+
+        for (XmlElement xmlElement : root.getChildren()) {
+            if (xmlElement.getQualifiedName().equalsIgnoreCase("p")) {
+                titleCollection.add(MediaWiki.htmlUnescape(xmlElement.getAttributeValue("title")));
+            } else {
+                findContent(xmlElement, titleCollection);
+            }
+
+        }
+    }
+
+    @Override
+    protected HttpAction prepareNextRequest() {
+        Optional<String> rpcontinue = nextPageInfoOpt();
+        if (rpcontinue.isPresent()) {
+            return generateRequest(namespaces, rpcontinue.get());
+        } else {
+            return generateRequest(namespaces);
+        }
+
+    }
+
+    @Override
+    protected Iterator<String> copy() {
+        return new net.sourceforge.jwbf.mediawiki.actions.queries.OldreviewedPagesTitles(bot, namespaces);
+    }
+
+    @Override
+    protected Optional<String> parseHasMore(final String xml) {
+        return parseXmlHasMore(xml, "reviewedpages", "rpstart", "rpstart");
+    }
 }

--- a/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/ReviewedPagesTitles.java
+++ b/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/ReviewedPagesTitles.java
@@ -142,7 +142,7 @@ public class ReviewedPagesTitles extends BaseQuery<String> {
 
     @Override
     protected Iterator<String> copy() {
-        return new OldreviewedPagesTitles(bot, namespaces);
+        return new ReviewedPagesTitles(bot, namespaces);
     }
 
     @Override

--- a/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/UnreviewedPagesTitles.java
+++ b/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/UnreviewedPagesTitles.java
@@ -38,12 +38,12 @@ import org.slf4j.LoggerFactory;
  */
 public class UnreviewedPagesTitles extends BaseQuery<String> {
 
-    private static final Logger log = LoggerFactory.getLogger(net.sourceforge.jwbf.mediawiki.actions.queries.UnreviewedPagesTitles.class);
+    private static final Logger log =  LoggerFactory.getLogger(UnreviewedPagesTitles.class);
     /**
      * value for the urlimit-parameter.
      *
      */
-    private static int LIMIT = 50;
+    private static final int LIMIT = 50;
     private final MediaWikiBot bot;
     private final int[] namespaces;
 
@@ -66,7 +66,8 @@ public class UnreviewedPagesTitles extends BaseQuery<String> {
                 .param("urlimit", LIMIT) //
                 ;
         if (namespace != null) {
-            requestBuilder.param("urnamespace", MediaWiki.urlEncode(MWAction.createNsString(namespace)));
+            String urnamespace = MediaWiki.urlEncode(MWAction.createNsString(namespace));
+            requestBuilder.param("urnamespace", urnamespace);
         }
         if (urstart.length() > 0) {
             requestBuilder.param("urstart", urstart);
@@ -142,7 +143,7 @@ public class UnreviewedPagesTitles extends BaseQuery<String> {
 
     @Override
     protected Iterator<String> copy() {
-        return new net.sourceforge.jwbf.mediawiki.actions.queries.UnreviewedPagesTitles(bot, namespaces);
+        return new UnreviewedPagesTitles(bot, namespaces);
     }
 
     @Override

--- a/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/UnreviewedPagesTitles.java
+++ b/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/UnreviewedPagesTitles.java
@@ -15,9 +15,6 @@
  */
 package net.sourceforge.jwbf.mediawiki.actions.queries;
 
-  
-
-
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -41,121 +38,115 @@ import org.slf4j.LoggerFactory;
  */
 public class UnreviewedPagesTitles extends BaseQuery<String> {
 
-  private static final Logger log = LoggerFactory.getLogger(net.sourceforge.jwbf.mediawiki.actions.queries.UnreviewedPagesTitles.class);
+    private static final Logger log = LoggerFactory.getLogger(net.sourceforge.jwbf.mediawiki.actions.queries.UnreviewedPagesTitles.class);
+    /**
+     * value for the urlimit-parameter.
+     *
+     */
+    private static int LIMIT;
+    private final MediaWikiBot bot;
+    private final int[] namespaces;
 
-  /**
-   * value for the urlimit-parameter. 
-   *
-   */
-  private static int LIMIT;
+    /**
+     * generates the next MediaWiki-request (GetMethod) and adds it to msgs.
+     *
+     * @param namespace the namespace(s) that will be searched for links, as a
+     * string of numbers separated by '|'; if null, this parameter is omitted
+     * @param urstart Start listing at this page title
+     *
+     * @param urend Stop listing at this page title
+     *
+     */
+    private HttpAction generateRequest(int[] namespace, String urstart, String urend) {
 
-  private final MediaWikiBot bot;
+        RequestBuilder requestBuilder = new ApiRequestBuilder() //
+                .action("query") //
+                .formatXml() //
+                .param("list", "unreviewedpages") //
+                .param("urlimit", LIMIT) //
+                ;
+        if (namespace != null) {
+            requestBuilder.param("urnamespace", MediaWiki.urlEncode(MWAction.createNsString(namespace)));
+        }
+        if (urstart.length() > 0) {
+            requestBuilder.param("urstart", urstart);
+        }
+        if (urend.length() > 0) {
+            requestBuilder.param("urend", urend);
+        }
 
-  private final int[] namespaces;
-
-  /**
-   * generates the next MediaWiki-request (GetMethod) and adds it to msgs.
-   *
-   * @param namespace the namespace(s) that will be searched for links, as a string of numbers
-   *                  separated by '|'; if null, this parameter is omitted
-   * @param urstart   Start listing at this page title
-   * 
-   * @param urend     Stop listing at this page title
-   * 
-   */
-  
-  private HttpAction generateRequest(int[] namespace, String urstart, String urend) {
-    
-    RequestBuilder requestBuilder = new ApiRequestBuilder() //
-        .action("query") //
-        .formatXml() //
-        .param("list", "unreviewedpages") //
-        .param("urlimit", LIMIT) //
-        ;
-    if (namespace != null) {
-      requestBuilder.param("urnamespace", MediaWiki.urlEncode(MWAction.createNsString(namespace)));
-    }
-    if (urstart.length() > 0) {
-      requestBuilder.param("urstart", urstart);
-    }
-    if(urend.length() > 0){
-        requestBuilder.param("urend", urend);
-    }
-
-    return requestBuilder.buildGet();
-
-  }
-  private HttpAction generateRequest(int[] namespace, String urstart) {
-      return generateRequest(namespace, urstart, "");
-  }
-  
-  private HttpAction generateRequest(int[] namespace) {
-    return generateRequest(namespace, "", "");
-  }
-
-  /**
-   *
-   */
-  public UnreviewedPagesTitles(MediaWikiBot bot, int... ns) {
-    super(bot);
-    namespaces = ns;
-    this.bot = bot;
-  }
-
-  /**
-   *
-   */
-  public UnreviewedPagesTitles(MediaWikiBot bot) {
-    this(bot, MediaWiki.NS_ALL);
-  }
-
-  /**
-   * picks the article name from a MediaWiki api response.
-   *
-   * @param s text for parsing
-   */
-  @Override
-  protected ImmutableList<String> parseElements(String s) {
-    XmlElement root = XmlConverter.getRootElement(s);
-    List<String> titleCollection = Lists.newArrayList();
-    findContent(root, titleCollection);
-    return ImmutableList.copyOf(titleCollection);
-
-  }
-
-  private void findContent(final XmlElement root, List<String> titleCollection) {
-
-    for (XmlElement xmlElement : root.getChildren()) {
-      if (xmlElement.getQualifiedName().equalsIgnoreCase("p")) {
-        titleCollection.add(MediaWiki.htmlUnescape(xmlElement.getAttributeValue("title")));
-        //Not sure about this, RecentChanges doesn't have timestamp either
-        setNextPageInfo(xmlElement.getAttributeValue("title"));
-      } else {
-        findContent(xmlElement, titleCollection);
-      }
+        return requestBuilder.buildGet();
 
     }
-  }
 
-  @Override
-  protected HttpAction prepareNextRequest() {
-    if (hasNextPageInfo()) {
-      return generateRequest(namespaces, getNextPageInfo());
-    } else {
-      return generateRequest(namespaces);
+    private HttpAction generateRequest(int[] namespace, String urstart) {
+        return generateRequest(namespace, urstart, "");
     }
 
-  }
+    private HttpAction generateRequest(int[] namespace) {
+        return generateRequest(namespace, "", "");
+    }
 
-  @Override
-  protected Iterator<String> copy() {
-    return new net.sourceforge.jwbf.mediawiki.actions.queries.UnreviewedPagesTitles(bot, namespaces);
-  }
+    /**
+     *
+     */
+    public UnreviewedPagesTitles(MediaWikiBot bot, int... ns) {
+        super(bot);
+        namespaces = ns;
+        this.bot = bot;
+    }
 
-  @Override
-  protected Optional<String> parseHasMore(String s) {
-    return Optional.absent();
-  }
+    /**
+     *
+     */
+    public UnreviewedPagesTitles(MediaWikiBot bot) {
+        this(bot, MediaWiki.NS_ALL);
+    }
 
+    /**
+     * picks the article name from a MediaWiki api response.
+     *
+     * @param s text for parsing
+     */
+    @Override
+    protected ImmutableList<String> parseElements(String s) {
+        XmlElement root = XmlConverter.getRootElement(s);
+        List<String> titleCollection = Lists.newArrayList();
+        findContent(root, titleCollection);
+        return ImmutableList.copyOf(titleCollection);
+
+    }
+
+    private void findContent(final XmlElement root, List<String> titleCollection) {
+
+        for (XmlElement xmlElement : root.getChildren()) {
+            if (xmlElement.getQualifiedName().equalsIgnoreCase("p")) {
+                titleCollection.add(MediaWiki.htmlUnescape(xmlElement.getAttributeValue("title")));
+            } else {
+                findContent(xmlElement, titleCollection);
+            }
+
+        }
+    }
+
+    @Override
+    protected HttpAction prepareNextRequest() {
+        Optional<String> urcontinue = nextPageInfoOpt();
+        if (urcontinue.isPresent()) {
+            return generateRequest(namespaces, urcontinue.get());
+        } else {
+            return generateRequest(namespaces);
+        }
+
+    }
+
+    @Override
+    protected Iterator<String> copy() {
+        return new net.sourceforge.jwbf.mediawiki.actions.queries.UnreviewedPagesTitles(bot, namespaces);
+    }
+
+    @Override
+    protected Optional<String> parseHasMore(final String xml) {
+        return parseXmlHasMore(xml, "unreviewedpages", "urstart", "urstart");
+    }
 }
-

--- a/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/UnreviewedPagesTitles.java
+++ b/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/UnreviewedPagesTitles.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2007, 2016 Thomas Stock, Marco Ammon.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.sourceforge.jwbf.mediawiki.actions.queries;
+
+  
+
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import java.util.Iterator;
+import java.util.List;
+import net.sourceforge.jwbf.core.actions.RequestBuilder;
+import net.sourceforge.jwbf.core.actions.util.HttpAction;
+import net.sourceforge.jwbf.mapper.XmlConverter;
+import net.sourceforge.jwbf.mapper.XmlElement;
+import net.sourceforge.jwbf.mediawiki.ApiRequestBuilder;
+import net.sourceforge.jwbf.mediawiki.MediaWiki;
+import net.sourceforge.jwbf.mediawiki.actions.util.MWAction;
+import net.sourceforge.jwbf.mediawiki.bots.MediaWikiBot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Gets a list of pages which have not been reviewed yet.
+ *
+ * @author Thomas Stock, Marco Ammon
+ */
+public class UnreviewedPagesTitles extends BaseQuery<String> {
+
+  private static final Logger log = LoggerFactory.getLogger(net.sourceforge.jwbf.mediawiki.actions.queries.UnreviewedPagesTitles.class);
+
+  /**
+   * value for the urlimit-parameter. 
+   *
+   */
+  private static int LIMIT;
+
+  private final MediaWikiBot bot;
+
+  private final int[] namespaces;
+
+  /**
+   * generates the next MediaWiki-request (GetMethod) and adds it to msgs.
+   *
+   * @param namespace the namespace(s) that will be searched for links, as a string of numbers
+   *                  separated by '|'; if null, this parameter is omitted
+   * @param urstart   Start listing at this page title
+   * 
+   * @param urend     Stop listing at this page title
+   * 
+   */
+  
+  private HttpAction generateRequest(int[] namespace, String urstart, String urend) {
+    
+    RequestBuilder requestBuilder = new ApiRequestBuilder() //
+        .action("query") //
+        .formatXml() //
+        .param("list", "unreviewedpages") //
+        .param("urlimit", LIMIT) //
+        ;
+    if (namespace != null) {
+      requestBuilder.param("urnamespace", MediaWiki.urlEncode(MWAction.createNsString(namespace)));
+    }
+    if (urstart.length() > 0) {
+      requestBuilder.param("urstart", urstart);
+    }
+    if(urend.length() > 0){
+        requestBuilder.param("urend", urend);
+    }
+
+    return requestBuilder.buildGet();
+
+  }
+  private HttpAction generateRequest(int[] namespace, String urstart) {
+      return generateRequest(namespace, urstart, "");
+  }
+  
+  private HttpAction generateRequest(int[] namespace) {
+    return generateRequest(namespace, "", "");
+  }
+
+  /**
+   *
+   */
+  public UnreviewedPagesTitles(MediaWikiBot bot, int... ns) {
+    super(bot);
+    namespaces = ns;
+    this.bot = bot;
+  }
+
+  /**
+   *
+   */
+  public UnreviewedPagesTitles(MediaWikiBot bot) {
+    this(bot, MediaWiki.NS_ALL);
+  }
+
+  /**
+   * picks the article name from a MediaWiki api response.
+   *
+   * @param s text for parsing
+   */
+  @Override
+  protected ImmutableList<String> parseElements(String s) {
+    XmlElement root = XmlConverter.getRootElement(s);
+    List<String> titleCollection = Lists.newArrayList();
+    findContent(root, titleCollection);
+    return ImmutableList.copyOf(titleCollection);
+
+  }
+
+  private void findContent(final XmlElement root, List<String> titleCollection) {
+
+    for (XmlElement xmlElement : root.getChildren()) {
+      if (xmlElement.getQualifiedName().equalsIgnoreCase("p")) {
+        titleCollection.add(MediaWiki.htmlUnescape(xmlElement.getAttributeValue("title")));
+        //Not sure about this, RecentChanges doesn't have timestamp either
+        setNextPageInfo(xmlElement.getAttributeValue("title"));
+      } else {
+        findContent(xmlElement, titleCollection);
+      }
+
+    }
+  }
+
+  @Override
+  protected HttpAction prepareNextRequest() {
+    if (hasNextPageInfo()) {
+      return generateRequest(namespaces, getNextPageInfo());
+    } else {
+      return generateRequest(namespaces);
+    }
+
+  }
+
+  @Override
+  protected Iterator<String> copy() {
+    return new net.sourceforge.jwbf.mediawiki.actions.queries.UnreviewedPagesTitles(bot, namespaces);
+  }
+
+  @Override
+  protected Optional<String> parseHasMore(String s) {
+    return Optional.absent();
+  }
+
+}
+

--- a/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/UnreviewedPagesTitles.java
+++ b/src/main/java/net/sourceforge/jwbf/mediawiki/actions/queries/UnreviewedPagesTitles.java
@@ -43,7 +43,7 @@ public class UnreviewedPagesTitles extends BaseQuery<String> {
      * value for the urlimit-parameter.
      *
      */
-    private static int LIMIT;
+    private static int LIMIT = 50;
     private final MediaWikiBot bot;
     private final int[] namespaces;
 

--- a/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/OldreviewedPagesTitlesIntegTest.java
+++ b/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/OldreviewedPagesTitlesIntegTest.java
@@ -50,7 +50,7 @@ public class OldreviewedPagesTitlesIntegTest extends AbstractIntegTest {
   public void test() {
 
     // GIVEN
-    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("oldreviewedpages_1.xml"));
+    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("oldreviewedpages.xml"));
     MediaWikiBot bot = new MediaWikiBot(host());
 
     // WHEN
@@ -70,7 +70,7 @@ public class OldreviewedPagesTitlesIntegTest extends AbstractIntegTest {
   public void testOne() {
 
     // GIVEN
-    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("oldreviewedpages_1.xml"));
+    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("oldreviewedpages.xml"));
     MediaWikiBot bot = new MediaWikiBot(host());
 
     // WHEN

--- a/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/OldreviewedPagesTitlesIntegTest.java
+++ b/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/OldreviewedPagesTitlesIntegTest.java
@@ -54,7 +54,7 @@ public class OldreviewedPagesTitlesIntegTest extends AbstractIntegTest {
     MediaWikiBot bot = new MediaWikiBot(host());
 
     // WHEN
-    UnreviewedPagesTitles testee = new UnreviewedPagesTitles(bot, MediaWiki.NS_MAIN);
+    OldreviewedPagesTitles testee = new OldreviewedPagesTitles(bot, MediaWiki.NS_MAIN);
     List<String> resultList = testee.getCopyOf(15); // query-continue is not implemented
 
     // THEN
@@ -74,7 +74,7 @@ public class OldreviewedPagesTitlesIntegTest extends AbstractIntegTest {
     MediaWikiBot bot = new MediaWikiBot(host());
 
     // WHEN
-    UnreviewedPagesTitles testee = new UnreviewedPagesTitles(bot, MediaWiki.NS_MAIN);
+    OldreviewedPagesTitles testee = new OldreviewedPagesTitles(bot, MediaWiki.NS_MAIN);
     List<String> resultList = testee.getCopyOf(1);
 
     // THEN

--- a/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/OldreviewedPagesTitlesIntegTest.java
+++ b/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/OldreviewedPagesTitlesIntegTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Marco Ammon <ammon.marco@t-online.de>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.sourceforge.jwbf.mediawiki.actions.queries;
+
+/**
+ *
+ * @author Marco Ammon <ammon.marco@t-online.de>
+ */
+
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import com.github.dreamhead.moco.RequestMatcher;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import net.sourceforge.jwbf.AbstractIntegTest;
+import net.sourceforge.jwbf.GAssert;
+import net.sourceforge.jwbf.TestHelper;
+import net.sourceforge.jwbf.mediawiki.ApiMatcherBuilder;
+import net.sourceforge.jwbf.mediawiki.MediaWiki;
+import net.sourceforge.jwbf.mediawiki.bots.MediaWikiBot;
+import org.junit.Test;
+
+public class OldreviewedPagesTitlesIntegTest extends AbstractIntegTest {
+
+  RequestMatcher embeddedinTwo = ApiMatcherBuilder.of() //
+      .param("action", "query") //
+      .param("format", "xml") //
+      .param("list", "oldreviewedpages") //
+      .param("orlimit", "50") //
+      .param("ornamespace", "0") //
+      .build();
+
+  @Test
+  public void test() {
+
+    // GIVEN
+    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("oldreviewedpages_1.xml"));
+    MediaWikiBot bot = new MediaWikiBot(host());
+
+    // WHEN
+    UnreviewedPagesTitles testee = new UnreviewedPagesTitles(bot, MediaWiki.NS_MAIN);
+    List<String> resultList = testee.getCopyOf(15); // query-continue is not implemented
+
+    // THEN
+    ImmutableList<String> expected = ImmutableList
+        .of("Team SC2Improve", "Honor",
+            "EURONICS Gaming", "Virtus.pro");
+    GAssert.assertEquals(expected, ImmutableList.copyOf(resultList));
+    assertEquals(resultList.size(), ImmutableSet.copyOf(resultList).size());
+
+  }
+
+  @Test
+  public void testOne() {
+
+    // GIVEN
+    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("oldreviewedpages_1.xml"));
+    MediaWikiBot bot = new MediaWikiBot(host());
+
+    // WHEN
+    UnreviewedPagesTitles testee = new UnreviewedPagesTitles(bot, MediaWiki.NS_MAIN);
+    List<String> resultList = testee.getCopyOf(1);
+
+    // THEN
+    ImmutableList<String> expected = ImmutableList.of("Team SC2Improve");
+    GAssert.assertEquals(expected, ImmutableList.copyOf(resultList));
+    assertEquals(resultList.size(), ImmutableSet.copyOf(resultList).size());
+
+  }
+
+}

--- a/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/ReviewedPagesTitlesIntegTest.java
+++ b/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/ReviewedPagesTitlesIntegTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Marco Ammon <ammon.marco@t-online.de>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.sourceforge.jwbf.mediawiki.actions.queries;
+
+/**
+ *
+ * @author Marco Ammon <ammon.marco@t-online.de>
+ */
+
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import com.github.dreamhead.moco.RequestMatcher;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import net.sourceforge.jwbf.AbstractIntegTest;
+import net.sourceforge.jwbf.GAssert;
+import net.sourceforge.jwbf.TestHelper;
+import net.sourceforge.jwbf.mediawiki.ApiMatcherBuilder;
+import net.sourceforge.jwbf.mediawiki.MediaWiki;
+import net.sourceforge.jwbf.mediawiki.bots.MediaWikiBot;
+import org.junit.Test;
+
+public class ReviewedPagesTitlesIntegTest extends AbstractIntegTest {
+
+  RequestMatcher embeddedinTwo = ApiMatcherBuilder.of() //
+      .param("action", "query") //
+      .param("format", "xml") //
+      .param("list", "reviewedpages") //
+      .param("rplimit", "50") //
+      .param("rpnamespace", "0") //
+      .build();
+
+  @Test
+  public void test() {
+
+    // GIVEN
+    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("reviewedpages_1.xml"));
+    MediaWikiBot bot = new MediaWikiBot(host());
+
+    // WHEN
+    ReviewedPagesTitles testee = new ReviewedPagesTitles(bot, MediaWiki.NS_MAIN);
+    List<String> resultList = testee.getCopyOf(15); // query-continue is not implemented
+
+    // THEN
+    ImmutableList<String> expected = ImmutableList
+        .of("Main Page", "Units/WoL",
+            "SCV (Wings of Liberty and Heart of the Swarm)", "Terran Units/WoL");
+    GAssert.assertEquals(expected, ImmutableList.copyOf(resultList));
+    assertEquals(resultList.size(), ImmutableSet.copyOf(resultList).size());
+
+  }
+
+  @Test
+  public void testOne() {
+
+    // GIVEN
+    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("reviewedpages_1.xml"));
+    MediaWikiBot bot = new MediaWikiBot(host());
+
+    // WHEN
+    ReviewedPagesTitles testee = new ReviewedPagesTitles(bot, MediaWiki.NS_MAIN);
+    List<String> resultList = testee.getCopyOf(1);
+
+    // THEN
+    ImmutableList<String> expected = ImmutableList.of("Main Page");
+    GAssert.assertEquals(expected, ImmutableList.copyOf(resultList));
+    assertEquals(resultList.size(), ImmutableSet.copyOf(resultList).size());
+
+  }
+
+}

--- a/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/ReviewedPagesTitlesIntegTest.java
+++ b/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/ReviewedPagesTitlesIntegTest.java
@@ -50,7 +50,7 @@ public class ReviewedPagesTitlesIntegTest extends AbstractIntegTest {
   public void test() {
 
     // GIVEN
-    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("reviewedpages_1.xml"));
+    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("reviewedpages.xml"));
     MediaWikiBot bot = new MediaWikiBot(host());
 
     // WHEN
@@ -70,7 +70,7 @@ public class ReviewedPagesTitlesIntegTest extends AbstractIntegTest {
   public void testOne() {
 
     // GIVEN
-    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("reviewedpages_1.xml"));
+    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("reviewedpages.xml"));
     MediaWikiBot bot = new MediaWikiBot(host());
 
     // WHEN

--- a/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/UnreviewedPagesTitlesIntegTest.java
+++ b/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/UnreviewedPagesTitlesIntegTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Marco Ammon <ammon.marco@t-online.de>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.sourceforge.jwbf.mediawiki.actions.queries;
+
+/**
+ *
+ * @author Marco Ammon <ammon.marco@t-online.de>
+ */
+
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import com.github.dreamhead.moco.RequestMatcher;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import net.sourceforge.jwbf.AbstractIntegTest;
+import net.sourceforge.jwbf.GAssert;
+import net.sourceforge.jwbf.TestHelper;
+import net.sourceforge.jwbf.mediawiki.ApiMatcherBuilder;
+import net.sourceforge.jwbf.mediawiki.MediaWiki;
+import net.sourceforge.jwbf.mediawiki.bots.MediaWikiBot;
+import org.junit.Test;
+
+public class UnreviewedPagesTitlesIntegTest extends AbstractIntegTest {
+
+  RequestMatcher embeddedinTwo = ApiMatcherBuilder.of() //
+      .param("action", "query") //
+      .param("format", "xml") //
+      .param("list", "unreviewedpages") //
+      .param("urlimit", "50") //
+      .param("urnamespace", "0") //
+      .build();
+
+  @Test
+  public void test() {
+
+    // GIVEN
+    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("unreviewedpages_1.xml"));
+    MediaWikiBot bot = new MediaWikiBot(host());
+
+    // WHEN
+    UnreviewedPagesTitles testee = new UnreviewedPagesTitles(bot, MediaWiki.NS_MAIN);
+    List<String> resultList = testee.getCopyOf(15); // query-continue is not implemented
+
+    // THEN
+    ImmutableList<String> expected = ImmutableList
+        .of("1-1-1", "2014-15 Season 1 eGamers Starcraft II Open/Participants",
+            "2014 WCS Season 1 Korea GSL", "4 Warpgate All In (vs. Protoss)");
+    GAssert.assertEquals(expected, ImmutableList.copyOf(resultList));
+    assertEquals(resultList.size(), ImmutableSet.copyOf(resultList).size());
+
+  }
+
+  @Test
+  public void testOne() {
+
+    // GIVEN
+    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("unreviewedpages_1.xml"));
+    MediaWikiBot bot = new MediaWikiBot(host());
+
+    // WHEN
+    UnreviewedPagesTitles testee = new UnreviewedPagesTitles(bot, MediaWiki.NS_MAIN);
+    List<String> resultList = testee.getCopyOf(1);
+
+    // THEN
+    ImmutableList<String> expected = ImmutableList.of("1-1-1");
+    GAssert.assertEquals(expected, ImmutableList.copyOf(resultList));
+    assertEquals(resultList.size(), ImmutableSet.copyOf(resultList).size());
+
+  }
+
+}

--- a/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/UnreviewedPagesTitlesIntegTest.java
+++ b/src/test/java/net/sourceforge/jwbf/mediawiki/actions/queries/UnreviewedPagesTitlesIntegTest.java
@@ -50,7 +50,7 @@ public class UnreviewedPagesTitlesIntegTest extends AbstractIntegTest {
   public void test() {
 
     // GIVEN
-    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("unreviewedpages_1.xml"));
+    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("unreviewedpages.xml"));
     MediaWikiBot bot = new MediaWikiBot(host());
 
     // WHEN
@@ -70,7 +70,7 @@ public class UnreviewedPagesTitlesIntegTest extends AbstractIntegTest {
   public void testOne() {
 
     // GIVEN
-    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("unreviewedpages_1.xml"));
+    server.request(embeddedinTwo).response(TestHelper.anyWikiResponse("unreviewedpages.xml"));
     MediaWikiBot bot = new MediaWikiBot(host());
 
     // WHEN

--- a/src/test/resources/mediawiki/any/oldreviewedpages.xml
+++ b/src/test/resources/mediawiki/any/oldreviewedpages.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <query>
+        <oldreviewedpages>
+            <p pageid="45530" ns="0" title="Team SC2Improve" revid="961488" stable_revid="945490" pending_since="2015-11-21T14:36:48Z" flagged_level="0" flagged_level_text="stable" diff_size="-1"/>
+            <p pageid="15537" ns="0" title="Honor" revid="971548" stable_revid="861713" pending_since="2015-12-20T23:01:31Z" flagged_level="0" flagged_level_text="stable" diff_size="503"/>
+            <p pageid="61687" ns="0" title="EURONICS Gaming" revid="974837" stable_revid="973673" pending_since="2015-12-31T14:33:13Z" flagged_level="0" flagged_level_text="stable" diff_size="213"/>
+            <p pageid="18143" ns="0" title="Virtus.pro" revid="976382" stable_revid="961967" pending_since="2016-01-04T23:11:58Z" flagged_level="0" flagged_level_text="stable" diff_size="0"/>
+        </oldreviewedpages>
+    </query>
+</api>

--- a/src/test/resources/mediawiki/any/oldreviewedpages_1.xml
+++ b/src/test/resources/mediawiki/any/oldreviewedpages_1.xml
@@ -1,0 +1,10 @@
+<api>
+    <query>
+        <oldreviewedpages>
+            <p pageid="45530" ns="0" title="Team SC2Improve" revid="961488" stable_revid="945490" pending_since="2015-11-21T14:36:48Z" flagged_level="0" flagged_level_text="stable" diff_size="-1"/>
+            <p pageid="15537" ns="0" title="Honor" revid="971548" stable_revid="861713" pending_since="2015-12-20T23:01:31Z" flagged_level="0" flagged_level_text="stable" diff_size="503"/>
+            <p pageid="61687" ns="0" title="EURONICS Gaming" revid="974837" stable_revid="973673" pending_since="2015-12-31T14:33:13Z" flagged_level="0" flagged_level_text="stable" diff_size="213"/>
+            <p pageid="18143" ns="0" title="Virtus.pro" revid="976382" stable_revid="961967" pending_since="2016-01-04T23:11:58Z" flagged_level="0" flagged_level_text="stable" diff_size="0"/>
+        </oldreviewedpages>
+    </query>
+</api>

--- a/src/test/resources/mediawiki/any/reviewedpages.xml
+++ b/src/test/resources/mediawiki/any/reviewedpages.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <query>
+        <reviewedpages>
+            <p pageid="1" ns="0" title="Main Page" revid="969931" stable_revid="969931" flagged_level="1" flagged_level_text="quality"/>
+            <p pageid="146" ns="0" title="Units/WoL" revid="772694" stable_revid="772694" flagged_level="0" flagged_level_text="stable"/>
+            <p pageid="147" ns="0" title="SCV (Wings of Liberty and Heart of the Swarm)" revid="965246" stable_revid="965246" flagged_level="0" flagged_level_text="stable"/>
+            <p pageid="148" ns="0" title="Terran Units/WoL" revid="939657" stable_revid="939657" flagged_level="0" flagged_level_text="stable"/>
+        </reviewedpages>
+    </query>
+</api>

--- a/src/test/resources/mediawiki/any/reviewedpages_1.xml
+++ b/src/test/resources/mediawiki/any/reviewedpages_1.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <warnings>
+        <query xml:space="preserve">Formatting of continuation data will be changing soon. To continue using the current formatting, use the 'rawcontinue' parameter. To begin using the new format, pass an empty string for 'continue' in the initial query.</query>
+    </warnings>
+    <query-continue>
+        <reviewedpages rpstart="221"/>
+    </query-continue>
+    <query>
+        <reviewedpages>
+            <p pageid="1" ns="0" title="Main Page" revid="969931" stable_revid="969931" flagged_level="1" flagged_level_text="quality"/>
+            <p pageid="146" ns="0" title="Units/WoL" revid="772694" stable_revid="772694" flagged_level="0" flagged_level_text="stable"/>
+            <p pageid="147" ns="0" title="SCV (Wings of Liberty and Heart of the Swarm)" revid="965246" stable_revid="965246" flagged_level="0" flagged_level_text="stable"/>
+            <p pageid="148" ns="0" title="Terran Units/WoL" revid="939657" stable_revid="939657" flagged_level="0" flagged_level_text="stable"/>
+        </reviewedpages>
+    </query>
+</api>

--- a/src/test/resources/mediawiki/any/reviewedpages_1.xml.xml
+++ b/src/test/resources/mediawiki/any/reviewedpages_1.xml.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <warnings>
+        <query xml:space="preserve">Formatting of continuation data will be changing soon. To continue using the current formatting, use the 'rawcontinue' parameter. To begin using the new format, pass an empty string for 'continue' in the initial query.</query>
+    </warnings>
+    <query-continue>
+        <reviewedpages rpstart="221"/>
+    </query-continue>
+    <query>
+        <reviewedpages>
+            <p pageid="1" ns="0" title="Main Page" revid="969931" stable_revid="969931" flagged_level="1" flagged_level_text="quality"/>
+            <p pageid="146" ns="0" title="Units/WoL" revid="772694" stable_revid="772694" flagged_level="0" flagged_level_text="stable"/>
+            <p pageid="147" ns="0" title="SCV (Wings of Liberty and Heart of the Swarm)" revid="965246" stable_revid="965246" flagged_level="0" flagged_level_text="stable"/>
+            <p pageid="148" ns="0" title="Terran Units/WoL" revid="939657" stable_revid="939657" flagged_level="0" flagged_level_text="stable"/>
+        </reviewedpages>
+    </query>
+</api>

--- a/src/test/resources/mediawiki/any/unreviewedpages.xml
+++ b/src/test/resources/mediawiki/any/unreviewedpages.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <query>
+        <unreviewedpages>
+            <p pageid="17455" ns="0" title="1-1-1" revid="147614"/>
+            <p pageid="53181" ns="0" title="2014-15 Season 1 eGamers Starcraft II Open/Participants" revid="810682"/>
+            <p pageid="42609" ns="0" title="2014 WCS Season 1 Korea GSL" revid="631460"/>
+            <p pageid="2667" ns="0" title="4 Warpgate All In (vs. Protoss)" revid="16772"/>
+        </unreviewedpages>
+    </query>
+</api>

--- a/src/test/resources/mediawiki/any/unreviewedpages_1.xml
+++ b/src/test/resources/mediawiki/any/unreviewedpages_1.xml
@@ -1,0 +1,16 @@
+<api>
+    <warnings>
+        <query xml:space="preserve">Formatting of continuation data will be changing soon. To continue using the current formatting, use the 'rawcontinue' parameter. To begin using the new format, pass an empty string for 'continue' in the initial query.</query>
+    </warnings>
+    <query-continue>
+        <unreviewedpages urstart="5_Rax_Reaper"/>
+    </query-continue>
+    <query>
+        <unreviewedpages>
+            <p pageid="17455" ns="0" title="1-1-1" revid="147614"/>
+            <p pageid="53181" ns="0" title="2014-15 Season 1 eGamers Starcraft II Open/Participants" revid="810682"/>
+            <p pageid="42609" ns="0" title="2014 WCS Season 1 Korea GSL" revid="631460"/>
+            <p pageid="2667" ns="0" title="4 Warpgate All In (vs. Protoss)" revid="16772"/>
+        </unreviewedpages>
+    </query>
+</api>


### PR DESCRIPTION
FlaggedRevs (https://www.mediawiki.org/wiki/Extension:FlaggedRevs) is a commonly used MediaWiki extension to organize revisions. It allows to review edits before making them available for public. It offers part of its functionality through the MediaWiki Action-API, for example lists of reviewed, unreviewed and oldreviewed (already reviewed, but unreviewed changes) pages. I added classes for these queries, based on RecentchangeTitles.